### PR TITLE
Disable migrations while testing closes #53

### DIFF
--- a/tests/application.py
+++ b/tests/application.py
@@ -1,4 +1,5 @@
 import pycodestyle
+import pytest
 
 
 def test_style():
@@ -12,3 +13,9 @@ def test_style():
     style = pycodestyle.StyleGuide(ignore=['E501', 'W504'])
     result = style.check_files(['config/', 'v1/'])
     assert not result.total_errors
+
+
+@pytest.mark.django_db
+def test_migration():
+    """Will run migration"""
+    assert True

--- a/tests/application.py
+++ b/tests/application.py
@@ -2,6 +2,15 @@ import pycodestyle
 import pytest
 
 
+@pytest.mark.django_db
+def test_migration():
+    """
+    Will run migration
+    """
+
+    assert True
+
+
 def test_style():
     """
     Test PEP 8 style conventions
@@ -13,9 +22,3 @@ def test_style():
     style = pycodestyle.StyleGuide(ignore=['E501', 'W504'])
     result = style.check_files(['config/', 'v1/'])
     assert not result.total_errors
-
-
-@pytest.mark.django_db
-def test_migration():
-    """Will run migration"""
-    assert True

--- a/v1/conftest.py
+++ b/v1/conftest.py
@@ -1,6 +1,8 @@
+from django.conf import settings
 import pytest
 from django.core.management import call_command
 from factory import Faker
+from pytest_django.migrations import DisableMigrations
 from thenewboston.accounts.manage import create_account
 from thenewboston.blocks.block import generate_block
 from thenewboston.third_party.pytest.client import UserWrapper
@@ -96,3 +98,9 @@ def self_configuration(monkeypatch):
 @pytest.fixture
 def validator(encoded_account_number):
     yield ValidatorFactory(node_identifier=encoded_account_number)
+
+
+@pytest.fixture(scope='session', autouse=True)
+def migrations_disabled():
+    settings.MIGRATION_MODULES = DisableMigrations()
+    yield None

--- a/v1/conftest.py
+++ b/v1/conftest.py
@@ -1,5 +1,5 @@
-from django.conf import settings
 import pytest
+from django.conf import settings
 from django.core.management import call_command
 from factory import Faker
 from pytest_django.migrations import DisableMigrations
@@ -76,6 +76,12 @@ def encoded_account_number(account_number):
     yield encode_verify_key(verify_key=account_number)
 
 
+@pytest.fixture(scope='session', autouse=True)
+def migrations_disabled():
+    settings.MIGRATION_MODULES = DisableMigrations()
+    yield None
+
+
 @pytest.fixture
 def random_encoded_account_number():
     _, account_number = create_account()
@@ -98,9 +104,3 @@ def self_configuration(monkeypatch):
 @pytest.fixture
 def validator(encoded_account_number):
     yield ValidatorFactory(node_identifier=encoded_account_number)
-
-
-@pytest.fixture(scope='session', autouse=True)
-def migrations_disabled():
-    settings.MIGRATION_MODULES = DisableMigrations()
-    yield None


### PR DESCRIPTION
Will not run migrations for any individual test or a group of tests from v1 module

Will run migration while executing test all