### PR TITLE
Add test_validator_confirmation_service

### DIFF
--- a/v1/validator_confirmation_services/tests/validator_confirmation_service.py
+++ b/v1/validator_confirmation_services/tests/validator_confirmation_service.py
@@ -3,7 +3,21 @@ from datetime import datetime, timedelta
 
 from rest_framework.reverse import reverse
 from rest_framework.status import HTTP_200_OK, HTTP_201_CREATED
+from thenewboston.third_party.pytest.asserts import assert_objects_vs_dicts
 from thenewboston.utils.signed_requests import generate_signed_request
+
+
+def test_validator_confirmation_service_list(
+    client, validator_confirmation_services, django_assert_max_num_queries,
+):
+    with django_assert_max_num_queries(2):
+        response = client.get_json(
+            reverse('validatorconfirmationservice-list'),
+            {'limit': 0},
+            expected=HTTP_200_OK,
+        )
+    assert_objects_vs_dicts(validator_confirmation_services, response)
+    assert response
 
 
 def test_validator_confirmation_service_filter(


### PR DESCRIPTION
Neat project! Taking a peek at the source code and adding the missing test on my way by. 😃

For https://github.com/thenewboston-developers/Bank/issues/110

```
$ docker-compose run app pytest -k validator_confirmation_service.py
Creating bank_app_run ... done
========================================================= test session starts ==========================================================
platform linux -- Python 3.8.6, pytest-6.1.2, py-1.9.0, pluggy-0.13.1
django: settings: config.settings.local (from env)
rootdir: /opt/project, configfile: pytest.ini
plugins: xdist-2.1.0, cov-2.10.1, celery-4.4.2, requests-mock-1.8.0, Faker-4.17.1, django-4.1.0, asyncio-0.14.0, forked-1.3.0
collected 61 items / 58 deselected / 3 selected

v1/validator_confirmation_services/tests/validator_confirmation_service.py ...                                                   [100%]

=========================================================== warnings summary ===========================================================
v1/validator_confirmation_services/tests/validator_confirmation_service.py::test_validator_confirmation_service_post_async
  /usr/local/lib/python3.8/site-packages/aioredis/connection.py:105: DeprecationWarning: The loop argument is deprecated
    warnings.warn("The loop argument is deprecated",

-- Docs: https://docs.pytest.org/en/stable/warnings.html
```